### PR TITLE
fix(model): dropout rate always greater than 1

### DIFF
--- a/net_manager.py
+++ b/net_manager.py
@@ -18,7 +18,7 @@ class NetManager():
 
     def get_reward(self, action, step, pre_acc):
         action = [action[0][0][x:x+4] for x in range(0, len(action[0][0]), 4)]
-        cnn_drop_rate = [c[3] for c in action]
+        cnn_drop_rate = [c[3] / 100.0 for c in action]
         with tf.Graph().as_default() as g:
             with g.container('experiment'+str(step)):
                 model = CNN(self.num_input, self.num_classes, action)


### PR DESCRIPTION
Hi, I was going through your wonderful blog post of NAS with RL and realized there is a tiny bug within the codebase.

The dropout rate extracted from `actions` is always greater than 1 because the RNNN's output is multiplied with `scalar=100.0`. I believe the reason is to convert most of the numbers within actions to be a large integer which will be used as number of filters, etc. However, if we do this to the dropout rate, it will never "drop" anything because it will always be larger than 1. In consequence this makes this dimension in the state has no impact on the reward.

This PR will fix this issue by simply divide the dropout rate with 100.0 before feeding into the CNN training.